### PR TITLE
add Swagger documentation for updating product details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.0.2</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/mipagina/update_product_service/config/OpenAPIConfig.java
+++ b/src/main/java/com/mipagina/update_product_service/config/OpenAPIConfig.java
@@ -1,0 +1,33 @@
+package com.mipagina.update_product_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIConfig {
+
+    @Bean
+    public OpenAPI myOpenAPI() {
+        Contact contact = new Contact();
+        contact.setEmail("youremail@example.com");
+        contact.setName("API Support");
+        contact.setUrl("https://www.yourwebsite.com");
+
+        License license = new License()
+                .name("Apache License 2.0")
+                .url("https://www.apache.org/licenses/LICENSE-2.0");
+
+        Info info = new Info()
+                .title("Update Product API")
+                .version("1.0")
+                .contact(contact)
+                .description("This API allows updating product details by ID.")
+                .license(license);
+
+        return new OpenAPI().info(info);
+    }
+}

--- a/src/main/java/com/mipagina/update_product_service/controller/ProductController.java
+++ b/src/main/java/com/mipagina/update_product_service/controller/ProductController.java
@@ -2,6 +2,11 @@ package com.mipagina.update_product_service.controller;
 
 import com.mipagina.update_product_service.model.Product;
 import com.mipagina.update_product_service.service.IProductService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -9,13 +14,25 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "Product", description = "API for updating product details")
 public class ProductController {
     @Autowired
     private IProductService productService;
 
+    @Operation(
+            summary = "Update a product by ID",
+            description = "Updates product details based on the given product ID.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Product updated successfully"),
+                    @ApiResponse(responseCode = "404", description = "Product not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
     @PutMapping("/edit/{id_product}")
-    public void editProduct(@PathVariable Long id_product,
-                            @RequestBody Product product){
-        productService.editProduct(id_product,product);
+    public void editProduct(
+            @Parameter(description = "ID of the product to be updated", required = true, example = "1")
+            @PathVariable Long id_product,
+            @RequestBody Product product) {
+        productService.editProduct(id_product, product);
     }
 }

--- a/src/main/java/com/mipagina/update_product_service/model/Product.java
+++ b/src/main/java/com/mipagina/update_product_service/model/Product.java
@@ -1,19 +1,32 @@
 package com.mipagina.update_product_service.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
+@Schema(description = "Product entity representing a product in the system")
 public class Product {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "Unique identifier of the product", example = "1")
     private Long id_product;
+
+    @Schema(description = "Name of the product", example = "Margherita Pizza", required = true)
     private String name;
+
+    @Schema(description = "Detailed description of the product", example = "Classic Italian pizza with mozzarella, tomato, and basil")
     private String description;
+
+    @Schema(description = "Price of the product", example = "12.99", required = true)
     private Double price;
+
+    @Schema(description = "Category ID to which the product belongs", example = "2", required = true)
     private Long id_category;
+
+    @Schema(description = "Product availability status", example = "true")
     private Boolean availability;
 
     public Long getId_product() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,5 +5,5 @@ eureka.client.service-url.defaultZone=http://localhost:8761/eureka
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://localhost:3306/products_service?serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=admin
+spring.datasource.password=12345
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
This update enhances the API documentation by adding Swagger annotations to the ProductController, specifically for the product update functionality. These changes improve clarity for developers working with the API.

Changes:
Added @Tag annotation to describe the Product API for updates.
Documented the editProduct endpoint using @Operation and @ApiResponse.
Included detailed parameter descriptions with @Parameter.
Specified possible response codes (200, 404, 500).
Reviewer: @JuanGuevara90